### PR TITLE
Update ros_install.sh

### DIFF
--- a/ros_install.sh
+++ b/ros_install.sh
@@ -65,9 +65,23 @@ if [ ! -e /etc/apt/sources.list.d/ros-latest.list ]; then
 fi
 
 echo "[Download the ROS keys]"
-roskey=`apt-key list | grep "ROS builder"`
+roskey=$(apt-key list | grep "ROS Builder")
 if [ -z "$roskey" ]; then
-  wget --quiet https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O - | sudo apt-key add -
+  if [ -n "$(command -v wget)" ]; then
+    tool="wget --quiet -O -"
+  elif [ -n "$(command -v curl)" ]; then
+    tool="curl --silent"
+  else
+    tool=""
+  fi
+  if [ -n "$tool" ]; then
+    $tool "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" | sudo apt-key add -
+  else
+    echo "Error: curl or wget not found"
+  fi
+  unset tool
+else
+  echo "ROS key is already installed"
 fi
 
 echo "[Update & upgrade the package]"


### PR DESCRIPTION
1. Fix grep filter: current ROS key has `ROS Builder <rosbuild@ros.org>` uid - so it doesn't match old `ROS builder` pattern, should match the new one.
2. Add curl support: Previous version was hardcoded to use only the wget without any fallback option, while [wiki entry about the script](http://wiki.ros.org/ROS/Installation/TwoLineInstall) offers curl usage too.